### PR TITLE
wrap json parse in try catch

### DIFF
--- a/src/iap_verifier.coffee
+++ b/src/iap_verifier.coffee
@@ -158,7 +158,11 @@ class IAPVerifier
       response.on 'end', () =>            
         totalData = apple_response_arr.join('')
         if @debug then console.log "end: apple response: #{totalData}"
-        responseData = JSON.parse(totalData)
+        try
+          responseData = JSON.parse(totalData)
+        catch err
+          if @debug then console.log("error: " + err)
+          return cb(false, "error", err)
         @processStatus(responseData, cb)
 
       


### PR DESCRIPTION
Was seeing this error on my server so added a try/catch block around the json parse.

undefined:0
^
SyntaxError: Unexpected end of input
at Object.parse (native)
at IncomingMessage.<anonymous> (/home/surespot/prod/surespot-web/node_modules/iap_verifier/lib/iap_verifier.js:241:31)
at IncomingMessage.EventEmitter.emit (events.js:117:20)
at _stream_readable.js:920:16
at process._tickCallback (node.js:415:13)
